### PR TITLE
Add DF keycode support

### DIFF
--- a/src/main/python/keycodes.py
+++ b/src/main/python/keycodes.py
@@ -539,6 +539,7 @@ def recreate_keyboard_keycodes(keyboard):
         KEYCODES_LAYERS.append(Keycode(0x5F11, "FN_MO23", "Fn2\n(Fn3)"))
 
     KEYCODES_LAYERS.extend(generate_keycodes_for_mask("MO", 0x5100))
+    KEYCODES_LAYERS.extend(generate_keycodes_for_mask("DF", 0x5200))
     KEYCODES_LAYERS.extend(generate_keycodes_for_mask("TG", 0x5300))
     KEYCODES_LAYERS.extend(generate_keycodes_for_mask("TT", 0x5800))
     KEYCODES_LAYERS.extend(generate_keycodes_for_mask("OSL", 0x5400))


### PR DESCRIPTION
# Description

The current version of Vial does not support the DF keycode from QMK that allows you to change the current default layer. It should probably exist and works just fine in the firmware.

Therefore this PR proposes the change to add the keycode to the mapping.

# Screenshots
Before:
<img width="234" alt="Screenshot 2021-04-03 at 17 31 52" src="https://user-images.githubusercontent.com/80705558/113483660-e0ae5180-94a4-11eb-804a-f8d6b25dc7e1.png">

After: 
<img width="1136" alt="Screenshot 2021-04-03 at 17 48 49" src="https://user-images.githubusercontent.com/80705558/113483659-de4bf780-94a4-11eb-8cb9-6a2e48579e95.png">
