### PR TITLE
fix: Fixed bug that crashes matrix_text when encoders are present

### DIFF
--- a/src/main/python/matrix_test.py
+++ b/src/main/python/matrix_test.py
@@ -89,13 +89,14 @@ class MatrixTest(BasicEditor):
 
         # write matrix state to keyboard widget
         for w in self.keyboardWidget.widgets:
-            row = w.desc.row
-            col = w.desc.col
+            if w.desc.row is not None and w.desc.col is not None:
+                row = w.desc.row
+                col = w.desc.col
 
-            if row < len(matrix) and col < len(matrix[row]):
-                w.setPressed(matrix[row][col])
-                if matrix[row][col]:
-                    w.setActive(True)
+                if row < len(matrix) and col < len(matrix[row]):
+                    w.setPressed(matrix[row][col])
+                    if matrix[row][col]:
+                        w.setActive(True)
         
         self.keyboardWidget.update_layout()
         self.keyboardWidget.update()


### PR DESCRIPTION
I Found a bug in the matrix_test code that causes the application to throw an error when trying to test a board with a vial encoder.
This is due to encoders not having matrix positions.

I added a check to make sure this does not happen anymore.