### PR TITLE
Added custom keycode functionality

### DIFF
--- a/src/main/python/keyboard_comm.py
+++ b/src/main/python/keyboard_comm.py
@@ -166,7 +166,7 @@ class Keyboard:
         self.macro_memory = 0
         self.macro = b""
         self.vibl = False
-        self.custom_keycodes = dict()
+        self.custom_keycodes = []
 
         self.via_protocol = self.vial_protocol = self.keyboard_id = -1
 
@@ -230,13 +230,12 @@ class Keyboard:
 
         if "customKeycodes" in payload:
             custom_keycodes = payload["customKeycodes"]
-            self.custom_keycodes = dict()
+            self.custom_keycodes = []
 
             for i in range(len(custom_keycodes)):
                 c_keycode = custom_keycodes[i]
-                qmk_id = "USER{0:02}".format(i)
                 new_c_keycode = CustomKeycode(c_keycode["name"], c_keycode["title"], c_keycode["shortName"])
-                self.custom_keycodes[qmk_id] = new_c_keycode
+                self.custom_keycodes.append(new_c_keycode)
 
         serial = KleSerial()
         kb = serial.deserialize(payload["layouts"]["keymap"])

--- a/src/main/python/keyboard_comm.py
+++ b/src/main/python/keyboard_comm.py
@@ -138,6 +138,11 @@ def macro_deserialize_v2(data):
                 out.append(cls(args))
     return out
 
+class CustomKeycode:
+    def __init__(self, name, title, shortName):
+        self.name = name
+        self.title = title
+        self.shortName = shortName
 
 class Keyboard:
     """ Low-level communication with a vial-enabled keyboard """
@@ -161,6 +166,7 @@ class Keyboard:
         self.macro_memory = 0
         self.macro = b""
         self.vibl = False
+        self.custom_keycodes = dict()
 
         self.via_protocol = self.vial_protocol = self.keyboard_id = -1
 
@@ -221,6 +227,16 @@ class Keyboard:
 
         self.rows = payload["matrix"]["rows"]
         self.cols = payload["matrix"]["cols"]
+
+        if "customKeycodes" in payload:
+            custom_keycodes = payload["customKeycodes"]
+            self.custom_keycodes = dict()
+
+            for i in range(len(custom_keycodes)):
+                c_keycode = custom_keycodes[i]
+                qmk_id = "USER{0:02}".format(i)
+                new_c_keycode = CustomKeycode(c_keycode["name"], c_keycode["title"], c_keycode["shortName"])
+                self.custom_keycodes[qmk_id] = new_c_keycode
 
         serial = KleSerial()
         kb = serial.deserialize(payload["layouts"]["keymap"])

--- a/src/main/python/keyboard_comm.py
+++ b/src/main/python/keyboard_comm.py
@@ -160,7 +160,7 @@ class Keyboard:
         self.macro_memory = 0
         self.macro = b""
         self.vibl = False
-        self.custom_keycodes = []
+        self.custom_keycodes = None
 
         self.via_protocol = self.vial_protocol = self.keyboard_id = -1
 
@@ -222,8 +222,7 @@ class Keyboard:
         self.rows = payload["matrix"]["rows"]
         self.cols = payload["matrix"]["cols"]
 
-        if "customKeycodes" in payload:
-            self.custom_keycodes = payload["customKeycodes"]
+        self.custom_keycodes = payload.get("customKeycodes", None)
 
         serial = KleSerial()
         kb = serial.deserialize(payload["layouts"]["keymap"])

--- a/src/main/python/keyboard_comm.py
+++ b/src/main/python/keyboard_comm.py
@@ -138,12 +138,6 @@ def macro_deserialize_v2(data):
                 out.append(cls(args))
     return out
 
-class CustomKeycode:
-    def __init__(self, name, title, shortName):
-        self.name = name
-        self.title = title
-        self.shortName = shortName
-
 class Keyboard:
     """ Low-level communication with a vial-enabled keyboard """
 
@@ -229,13 +223,7 @@ class Keyboard:
         self.cols = payload["matrix"]["cols"]
 
         if "customKeycodes" in payload:
-            custom_keycodes = payload["customKeycodes"]
-            self.custom_keycodes = []
-
-            for i in range(len(custom_keycodes)):
-                c_keycode = custom_keycodes[i]
-                new_c_keycode = CustomKeycode(c_keycode["name"], c_keycode["title"], c_keycode["shortName"])
-                self.custom_keycodes.append(new_c_keycode)
+            self.custom_keycodes = payload["customKeycodes"]
 
         serial = KleSerial()
         kb = serial.deserialize(payload["layouts"]["keymap"])

--- a/src/main/python/keycodes.py
+++ b/src/main/python/keycodes.py
@@ -542,7 +542,6 @@ def recreate_keyboard_keycodes(keyboard):
     KEYCODES_USER.clear()
     for x in range(len(keyboard.custom_keycodes)):
         c_keycode = keyboard.custom_keycodes[x]
-        lbl = "USER{0:02}".format(x)
         KEYCODES_USER.append(Keycode(0x5F80 + x, c_keycode.shortName, c_keycode.name, c_keycode.title))
 
     recreate_keycodes()

--- a/src/main/python/keycodes.py
+++ b/src/main/python/keycodes.py
@@ -504,6 +504,29 @@ def recreate_keycodes():
     KEYCODES.extend(KEYCODES_SPECIAL + KEYCODES_BASIC + KEYCODES_SHIFTED + KEYCODES_ISO + KEYCODES_LAYERS +
                     KEYCODES_QUANTUM + KEYCODES_BACKLIGHT + KEYCODES_MEDIA + KEYCODES_MACRO + KEYCODES_USER)
 
+def create_user_keycodes():
+    KEYCODES_USER.clear()
+    for x in range(16):
+        KEYCODES_USER.append(
+            Keycode(
+                0x5F80 + x,
+                "USER{:02}".format(x),
+                "User {}".format(x),
+                "User keycode {}".format(x)
+            )
+        )
+
+def create_custom_user_keycodes(custom_keycodes):
+    KEYCODES_USER.clear()
+    for x, c_keycode in enumerate(custom_keycodes):
+        KEYCODES_USER.append(
+            Keycode(
+                0x5F80 + x,
+                c_keycode.get("shortName", "USER{:02}".format(x)),
+                c_keycode.get("name", "USER{:02}".format(x)),
+                c_keycode.get("title", "USER{:02}".format(x))
+            )
+        )
 
 def recreate_keyboard_keycodes(keyboard):
     """ Generates keycodes based on information the keyboard provides (e.g. layer keycodes, macros) """
@@ -539,12 +562,12 @@ def recreate_keyboard_keycodes(keyboard):
         lbl = "M{}".format(x)
         KEYCODES_MACRO.append(Keycode(0x5F12 + x, lbl, lbl))
 
-    KEYCODES_USER.clear()
-    for x in range(len(keyboard.custom_keycodes)):
-        c_keycode = keyboard.custom_keycodes[x]
-        KEYCODES_USER.append(Keycode(0x5F80 + x, c_keycode.shortName, c_keycode.name, c_keycode.title))
+    # Check if custom keycodes are defined in keyboard, and if so add them to user keycodes
+    if keyboard.custom_keycodes is not None and len(keyboard.custom_keycodes) > 0:
+        create_custom_user_keycodes(keyboard.custom_keycodes)
+    else:
+        create_user_keycodes()
 
     recreate_keycodes()
-
 
 recreate_keycodes()

--- a/src/main/python/keycodes.py
+++ b/src/main/python/keycodes.py
@@ -488,24 +488,7 @@ KEYCODES_MEDIA = [
     K(132, "KC_LSCR", "Locking\nScroll", "Locking Scroll Lock", alias=["KC_LOCKING_SCROLL"]),
 ]
 
-KEYCODES_USER = [
-    K(0x5F80, "USER00", "User 0", "User keycode 0"),
-    K(0x5F81, "USER01", "User 1", "User keycode 1"),
-    K(0x5F82, "USER02", "User 2", "User keycode 2"),
-    K(0x5F83, "USER03", "User 3", "User keycode 3"),
-    K(0x5F84, "USER04", "User 4", "User keycode 4"),
-    K(0x5F85, "USER05", "User 5", "User keycode 5"),
-    K(0x5F86, "USER06", "User 6", "User keycode 6"),
-    K(0x5F87, "USER07", "User 7", "User keycode 7"),
-    K(0x5F88, "USER08", "User 8", "User keycode 8"),
-    K(0x5F89, "USER09", "User 9", "User keycode 9"),
-    K(0x5F8A, "USER10", "User 10", "User keycode 10"),
-    K(0x5F8B, "USER11", "User 11", "User keycode 11"),
-    K(0x5F8C, "USER12", "User 12", "User keycode 12"),
-    K(0x5F8D, "USER13", "User 13", "User keycode 13"),
-    K(0x5F8E, "USER14", "User 14", "User keycode 14"),
-    K(0x5F8F, "USER15", "User 15", "User keycode 15"),
-]
+KEYCODES_USER = []
 
 KEYCODES_MACRO = []
 
@@ -555,6 +538,12 @@ def recreate_keyboard_keycodes(keyboard):
     for x in range(keyboard.macro_count):
         lbl = "M{}".format(x)
         KEYCODES_MACRO.append(Keycode(0x5F12 + x, lbl, lbl))
+
+    KEYCODES_USER.clear()
+    for x in range(len(keyboard.custom_keycodes)):
+        c_keycode = keyboard.custom_keycodes[x]
+        lbl = "USER{0:02}".format(x)
+        KEYCODES_USER.append(Keycode(0x5F80 + x, c_keycode.shortName, c_keycode.name, c_keycode.title))
 
     recreate_keycodes()
 

--- a/src/main/python/keymap_editor.py
+++ b/src/main/python/keymap_editor.py
@@ -47,7 +47,6 @@ class KeymapEditor(BasicEditor):
         layout_editor.changed.connect(self.on_layout_changed)
 
         self.keymap_override = KEYMAPS[0][1]
-        self.custom_keycodes = dict()
 
         self.container.anykey.connect(self.on_any_keycode)
 
@@ -87,9 +86,6 @@ class KeymapEditor(BasicEditor):
             # get number of layers
             self.rebuild_layers()
 
-            # get custom keycodes
-            self.custom_keycodes = self.keyboard.custom_keycodes
-
             self.container.set_keys(self.keyboard.keys, self.keyboard.encoders)
 
             self.current_layer = 0
@@ -97,7 +93,6 @@ class KeymapEditor(BasicEditor):
 
             recreate_keyboard_keycodes(self.keyboard)
             self.tabbed_keycodes.recreate_keycode_buttons()
-            self.tabbed_keycodes.set_custom_keycodes(self.custom_keycodes)
             self.refresh_layer_display()
 
     def valid(self):
@@ -135,25 +130,11 @@ class KeymapEditor(BasicEditor):
         key = Keycode.find_outer_keycode(code)
         return key is not None and key.qmk_id in self.keymap_override
 
-    def code_is_custom(self, code):
-        key = Keycode.find_outer_keycode(code)
-        return key is not None and key.qmk_id in self.custom_keycodes
-
     def get_label(self, code):
         """ Get label for a specific keycode """
         if self.code_is_overriden(code):
             return self.keymap_override[Keycode.find_outer_keycode(code).qmk_id]
-        if self.code_is_custom(code):
-            return self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].shortName
         return Keycode.label(code)
-
-    def get_tooltip(self, code):
-        if self.code_is_custom(code):
-            name = self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].shortName
-            title = self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].title
-            return "{0}: {1}".format(name, title)
-        else:
-            return Keycode.tooltip(code)
 
     def code_for_widget(self, widget):
         if widget.desc.row is not None:
@@ -174,7 +155,7 @@ class KeymapEditor(BasicEditor):
         for widget in self.container.widgets:
             code = self.code_for_widget(widget)
             text = self.get_label(code)
-            tooltip = self.get_tooltip(code)
+            tooltip = Keycode.tooltip(code)
             mask = Keycode.is_mask(code)
             mask_text = self.get_label(code & 0xFF)
             if mask:

--- a/src/main/python/keymap_editor.py
+++ b/src/main/python/keymap_editor.py
@@ -47,6 +47,7 @@ class KeymapEditor(BasicEditor):
         layout_editor.changed.connect(self.on_layout_changed)
 
         self.keymap_override = KEYMAPS[0][1]
+        self.custom_keycodes = dict()
 
         self.container.anykey.connect(self.on_any_keycode)
 
@@ -86,6 +87,9 @@ class KeymapEditor(BasicEditor):
             # get number of layers
             self.rebuild_layers()
 
+            # get custom keycodes
+            self.custom_keycodes = self.keyboard.custom_keycodes
+
             self.container.set_keys(self.keyboard.keys, self.keyboard.encoders)
 
             self.current_layer = 0
@@ -93,6 +97,7 @@ class KeymapEditor(BasicEditor):
 
             recreate_keyboard_keycodes(self.keyboard)
             self.tabbed_keycodes.recreate_keycode_buttons()
+            self.tabbed_keycodes.set_custom_keycodes(self.custom_keycodes)
             self.refresh_layer_display()
 
     def valid(self):
@@ -130,11 +135,25 @@ class KeymapEditor(BasicEditor):
         key = Keycode.find_outer_keycode(code)
         return key is not None and key.qmk_id in self.keymap_override
 
+    def code_is_custom(self, code):
+        key = Keycode.find_outer_keycode(code)
+        return key is not None and key.qmk_id in self.custom_keycodes
+
     def get_label(self, code):
         """ Get label for a specific keycode """
         if self.code_is_overriden(code):
             return self.keymap_override[Keycode.find_outer_keycode(code).qmk_id]
+        if self.code_is_custom(code):
+            return self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].shortName
         return Keycode.label(code)
+
+    def get_tooltip(self, code):
+        if self.code_is_custom(code):
+            name = self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].shortName
+            title = self.custom_keycodes[Keycode.find_outer_keycode(code).qmk_id].title
+            return "{0}: {1}".format(name, title)
+        else:
+            return Keycode.tooltip(code)
 
     def code_for_widget(self, widget):
         if widget.desc.row is not None:
@@ -155,7 +174,7 @@ class KeymapEditor(BasicEditor):
         for widget in self.container.widgets:
             code = self.code_for_widget(widget)
             text = self.get_label(code)
-            tooltip = Keycode.tooltip(code)
+            tooltip = self.get_tooltip(code)
             mask = Keycode.is_mask(code)
             mask_text = self.get_label(code & 0xFF)
             if mask:

--- a/src/main/python/square_button.py
+++ b/src/main/python/square_button.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
-from PyQt5.QtCore import QSize
-from PyQt5.QtWidgets import QPushButton
+from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtWidgets import QPushButton, QLabel, QHBoxLayout
 
 class SquareButton(QPushButton):
 
@@ -9,11 +9,37 @@ class SquareButton(QPushButton):
         super().__init__(parent)
 
         self.scale = 1.2
+        self.label = None
+        self.word_wrap = False
+        self.text = ""
 
     def setRelSize(self, ratio):
         self.scale = ratio
         self.updateGeometry()
 
+    def setWordWrap(self, state):
+        self.word_wrap = state
+        self.setText(self.text)
+
     def sizeHint(self):
         size = int(round(self.fontMetrics().height() * self.scale))
         return QSize(size, size)
+
+    # Override setText to facilitate automatic word wrapping
+    def setText(self, text):
+        self.text = text
+        if self.word_wrap:
+            super().setText("")
+            if self.label is None:
+                self.label = QLabel(text, self)
+                self.label.setWordWrap(True)
+                self.label.setAlignment(Qt.AlignCenter)
+                layout = QHBoxLayout(self)
+                layout.setContentsMargins(0, 0, 0, 0)
+                layout.addWidget(self.label,0,Qt.AlignCenter)
+            else:
+                self.label.setText(text)
+        else:
+            if self.label is not None:
+                self.label.deleteLater()
+            super().setText(text)

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -97,7 +97,7 @@ class TabbedKeycodes(QTabWidget):
             btn.deleteLater()
         self.layer_keycode_buttons = self.create_buttons(self.layout_layers, KEYCODES_LAYERS)
         self.macro_keycode_buttons = self.create_buttons(self.layout_macro, KEYCODES_MACRO)
-        self.user_keycode_buttons = self.create_buttons(self.layout_user, KEYCODES_USER, True)
+        self.user_keycode_buttons = self.create_buttons(self.layout_user, KEYCODES_USER, wordWrap=True)
         self.widgets += self.layer_keycode_buttons + self.macro_keycode_buttons + self.user_keycode_buttons
         self.relabel_buttons()
 

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QTabWidget, QWidget, QScrollArea, QApplication
+from PyQt5.QtWidgets import QTabWidget, QWidget, QScrollArea, QApplication, QLabel
 from PyQt5.QtGui import QPalette
 
 from constants import KEYCODE_BTN_RATIO
@@ -22,6 +22,7 @@ class TabbedKeycodes(QTabWidget):
         super().__init__(parent)
 
         self.keymap_override = None
+        self.custom_keycodes = None
 
         self.tab_basic = QScrollArea()
         self.tab_iso = QScrollArea()
@@ -100,14 +101,29 @@ class TabbedKeycodes(QTabWidget):
         self.keymap_override = override
         self.relabel_buttons()
 
+    def set_custom_keycodes(self, custom_keycodes):
+        self.custom_keycodes = custom_keycodes
+        self.relabel_buttons()
+
     def relabel_buttons(self):
         for widget in self.widgets:
             qmk_id = widget.keycode.qmk_id
-            if qmk_id in self.keymap_override:
+            if self.keymap_override is not None and qmk_id in self.keymap_override:
                 label = self.keymap_override[qmk_id]
                 highlight_color = QApplication.palette().color(QPalette.Link).getRgb()
                 widget.setStyleSheet("QPushButton {color: rgb"+str(highlight_color)+";}")
+                widget.setWordWrap(False)
+            elif self.custom_keycodes is not None and qmk_id in self.custom_keycodes:
+                label = self.custom_keycodes[qmk_id].name
+                name = self.custom_keycodes[qmk_id].shortName
+                title = self.custom_keycodes[qmk_id].title
+                tooltip = "{0}: {1}".format(name, title)
+                highlight_color = QApplication.palette().color(QPalette.Link).getRgb()
+                widget.setStyleSheet("color: rgb"+str(highlight_color)+";")
+                widget.setToolTip(tooltip)
+                widget.setWordWrap(True)
             else:
                 label = widget.keycode.label
                 widget.setStyleSheet("QPushButton {}")
+                widget.setWordWrap(False)
             widget.setText(label.replace("&", "&&"))

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtWidgets import QTabWidget, QWidget, QScrollArea, QApplication, QLabel
+from PyQt5.QtWidgets import QTabWidget, QWidget, QScrollArea, QApplication
 from PyQt5.QtGui import QPalette
 
 from constants import KEYCODE_BTN_RATIO
@@ -22,7 +22,6 @@ class TabbedKeycodes(QTabWidget):
         super().__init__(parent)
 
         self.keymap_override = None
-        self.custom_keycodes = None
 
         self.tab_basic = QScrollArea()
         self.tab_iso = QScrollArea()
@@ -50,6 +49,8 @@ class TabbedKeycodes(QTabWidget):
                 self.layout_layers = layout
             elif tab == self.tab_macro:
                 self.layout_macro = layout
+            elif tab == self.tab_user:
+                self.layout_user = layout
             elif tab == self.tab_basic:
                 # create the "Any" keycode button
                 btn = SquareButton()
@@ -71,13 +72,15 @@ class TabbedKeycodes(QTabWidget):
 
         self.layer_keycode_buttons = []
         self.macro_keycode_buttons = []
+        self.user_keycode_buttons = []
         self.set_keymap_override(KEYMAPS[0][1])
 
-    def create_buttons(self, layout, keycodes):
+    def create_buttons(self, layout, keycodes, wordWrap = False):
         buttons = []
 
         for keycode in keycodes:
             btn = SquareButton()
+            btn.setWordWrap(wordWrap)
             btn.setRelSize(KEYCODE_BTN_RATIO)
             btn.setToolTip(Keycode.tooltip(keycode.code))
             btn.clicked.connect(lambda st, k=keycode: self.keycode_changed.emit(k.code))
@@ -88,42 +91,28 @@ class TabbedKeycodes(QTabWidget):
         return buttons
 
     def recreate_keycode_buttons(self):
-        for btn in self.layer_keycode_buttons + self.macro_keycode_buttons:
+        for btn in self.layer_keycode_buttons + self.macro_keycode_buttons + self.user_keycode_buttons:
             self.widgets.remove(btn)
             btn.hide()
             btn.deleteLater()
         self.layer_keycode_buttons = self.create_buttons(self.layout_layers, KEYCODES_LAYERS)
         self.macro_keycode_buttons = self.create_buttons(self.layout_macro, KEYCODES_MACRO)
-        self.widgets += self.layer_keycode_buttons + self.macro_keycode_buttons
+        self.user_keycode_buttons = self.create_buttons(self.layout_user, KEYCODES_USER, True)
+        self.widgets += self.layer_keycode_buttons + self.macro_keycode_buttons + self.user_keycode_buttons
         self.relabel_buttons()
 
     def set_keymap_override(self, override):
         self.keymap_override = override
         self.relabel_buttons()
 
-    def set_custom_keycodes(self, custom_keycodes):
-        self.custom_keycodes = custom_keycodes
-        self.relabel_buttons()
-
     def relabel_buttons(self):
         for widget in self.widgets:
             qmk_id = widget.keycode.qmk_id
-            if self.keymap_override is not None and qmk_id in self.keymap_override:
+            if qmk_id in self.keymap_override:
                 label = self.keymap_override[qmk_id]
                 highlight_color = QApplication.palette().color(QPalette.Link).getRgb()
                 widget.setStyleSheet("QPushButton {color: rgb"+str(highlight_color)+";}")
-                widget.setWordWrap(False)
-            elif self.custom_keycodes is not None and qmk_id in self.custom_keycodes:
-                label = self.custom_keycodes[qmk_id].name
-                name = self.custom_keycodes[qmk_id].shortName
-                title = self.custom_keycodes[qmk_id].title
-                tooltip = "{0}: {1}".format(name, title)
-                highlight_color = QApplication.palette().color(QPalette.Link).getRgb()
-                widget.setStyleSheet("color: rgb"+str(highlight_color)+";")
-                widget.setToolTip(tooltip)
-                widget.setWordWrap(True)
             else:
                 label = widget.keycode.label
                 widget.setStyleSheet("QPushButton {}")
-                widget.setWordWrap(False)
             widget.setText(label.replace("&", "&&"))


### PR DESCRIPTION
I've added some code to allow you to define custom keycodes in the vial.json
For the format I've made use of the customKeycode schema in use in VIA.
The most thorough documentation I found on this was https://github.com/jjesuscastro/qmk_firmware/tree/master/keyboards/kbdfans/kbd67/rev2/keymaps/jjesuscastrol

To account for long keycode descriptors I've added automatic wrap functionality to SquareButton, which can be turned on with SquareButton.setWordWrap(True)

Hope this is usefull.

I'm open to feedback


Keyboard/keymap used for testing
https://github.com/Pieterv24/vial-qmk/tree/keyboards/keyboards/handwired/pieterv24/bento/keymaps/deej