### PR TITLE
Deselect key in keymap editor when container is clicked

### DIFF
--- a/src/main/python/basic_editor.py
+++ b/src/main/python/basic_editor.py
@@ -13,3 +13,6 @@ class BasicEditor(QVBoxLayout):
 
     def rebuild(self, device):
         self.device = device
+
+    def on_container_clicked(self):
+        pass

--- a/src/main/python/editor_container.py
+++ b/src/main/python/editor_container.py
@@ -1,0 +1,16 @@
+from PyQt5.QtWidgets import QWidget
+from PyQt5.QtCore import pyqtSignal
+
+
+class EditorContainer(QWidget):
+
+    clicked = pyqtSignal()
+
+    def __init__(self, editor):
+        super().__init__()
+
+        self.setLayout(editor)
+        self.clicked.connect(editor.on_container_clicked)
+
+    def mousePressEvent(self, ev):
+        self.clicked.emit()

--- a/src/main/python/keymap_editor.py
+++ b/src/main/python/keymap_editor.py
@@ -59,6 +59,11 @@ class KeymapEditor(BasicEditor):
 
         self.device = None
 
+    def on_container_clicked(self):
+        """ Called when a mouse click event is bubbled up to the editor's container """
+        self.container.deselect()
+        self.container.update()
+
     def on_keycode_changed(self, code):
         self.set_key(code)
 
@@ -142,6 +147,10 @@ class KeymapEditor(BasicEditor):
         else:
             return self.keyboard.encoder_layout[(self.current_layer, widget.desc.encoder_idx,
                                                  widget.desc.encoder_dir)]
+
+    def mousePressEvent(self, ev):
+        self.container.deselect()
+        self.container.update()
 
     def refresh_layer_display(self):
         """ Refresh text on key widgets to display data corresponding to current layer """

--- a/src/main/python/main_window.py
+++ b/src/main/python/main_window.py
@@ -8,6 +8,7 @@ import json
 import os
 from urllib.request import urlopen
 
+from editor_container import EditorContainer
 from firmware_flasher import FirmwareFlasher
 from keymap_editor import KeymapEditor
 from keymaps import KEYMAPS
@@ -245,9 +246,8 @@ class MainWindow(QMainWindow):
             if not container.valid():
                 continue
 
-            w = QWidget()
-            w.setLayout(container)
-            self.tabs.addTab(w, tr("MainWindow", lbl))
+            c = EditorContainer(container)
+            self.tabs.addTab(c, tr("MainWindow", lbl))
 
     def load_via_stack_json(self):
         data = urlopen("https://github.com/vial-kb/via-keymap-precompiled/raw/main/via_keyboard_stack.json")


### PR DESCRIPTION
Small UI change to allow the deselection of a currently-selected key in the keymap editor when the editor's container is clicked.

- Adds an EditorContainer to handle mouse click events on an editor's container widget.
- Adds a handler for container mouse click events to KeymapEditor to deselect and cancel a key selection.