### PR TITLE
Clean up mousePressEvent handler from KeymapEditor

### DIFF
--- a/src/main/python/keymap_editor.py
+++ b/src/main/python/keymap_editor.py
@@ -148,10 +148,6 @@ class KeymapEditor(BasicEditor):
             return self.keyboard.encoder_layout[(self.current_layer, widget.desc.encoder_idx,
                                                  widget.desc.encoder_dir)]
 
-    def mousePressEvent(self, ev):
-        self.container.deselect()
-        self.container.update()
-
     def refresh_layer_display(self):
         """ Refresh text on key widgets to display data corresponding to current layer """
 


### PR DESCRIPTION
Turns out that the `mousePressEvent` handler in KeymapEditor isn't needed with the handler in the container.