### PR TITLE
This "fixes" the issue with vertically staggered keyboards jumping to "random" keys.

### DIFF
--- a/src/main/python/widgets/keyboard_widget.py
+++ b/src/main/python/widgets/keyboard_widget.py
@@ -344,7 +344,7 @@ class KeyboardWidget(QWidget):
         self.place_widgets()
         self.widgets = list(filter(lambda w: not w.desc.decal, self.widgets))
 
-        self.widgets.sort(key=lambda w: (w.y, w.x))
+        # self.widgets.sort(key=lambda w: (w.y, w.x))
 
         # determine maximum width and height of container
         max_w = max_h = 0


### PR DESCRIPTION
This technically fixes the bug associated with vial-kb/vial-gui#123, but obviously that line of code is there for a *reason*. This is more of a proof-of-concept that this line is what's causing the keys being sorted in a non-sane way on v-staggered keyboards. Perhaps either a new boolean field in the qmk JSON called `UseJsonKeyOrder`? 

If `UseJsonKeyOrder == null || UseJsonKeyOrder == false`, then still sort the keys by Y, then X, if `UseJsonKeyOrder == true`, then use whatever order is in the JSON keymap.

This would allow the maintainer of the vial keymap for a keyboard to say "no, seriously, I have these in the right order, don't screw with things." without causing problems for keymaps that may be entered in a non-sane order.