### PR TITLE
Add security menu shortcuts

### DIFF
--- a/src/main/python/main_window.py
+++ b/src/main/python/main_window.py
@@ -172,12 +172,15 @@ class MainWindow(QMainWindow):
             file_menu.addAction(exit_act)
 
         keyboard_unlock_act = QAction(tr("MenuSecurity", "Unlock"), self)
+        keyboard_unlock_act.setShortcut("Ctrl+U")
         keyboard_unlock_act.triggered.connect(self.unlock_keyboard)
 
         keyboard_lock_act = QAction(tr("MenuSecurity", "Lock"), self)
+        keyboard_lock_act.setShortcut("Ctrl+L")
         keyboard_lock_act.triggered.connect(self.lock_keyboard)
 
         keyboard_reset_act = QAction(tr("MenuSecurity", "Reboot to bootloader"), self)
+        keyboard_reset_act.setShortcut("Ctrl+B")
         keyboard_reset_act.triggered.connect(self.reboot_to_bootloader)
 
         keyboard_layout_menu = self.menuBar().addMenu(tr("Menu", "Keyboard layout"))


### PR DESCRIPTION
Add the following keyboard shortcuts:

 * Ctrl/Cmd + U — **U**nlock
 * Ctrl/Cmd + L — **L**ock
 * Ctrl/Cmd + B\* — Reboot to **b**ootloader

\* “B” was selected rather than “R” since users in the process of switching from QWERTY to Colemak are likely to accidentally hit Ctrl+R when they meant Ctrl+S, and this could cause data loss.