### PR TITLE
Increased possible macros

### DIFF
--- a/src/main/python/editor/macro_recorder.py
+++ b/src/main/python/editor/macro_recorder.py
@@ -47,15 +47,6 @@ class MacroRecorder(BasicEditor):
         self.recording_append = False
 
         self.tabs = TabWidgetWithKeycodes()
-        for x in range(32):
-            tab = MacroTab(self, self.recorder is not None)
-            tab.changed.connect(self.on_change)
-            tab.record.connect(self.on_record)
-            tab.record_stop.connect(self.on_tab_stop)
-            self.macro_tabs.append(tab)
-            w = QWidget()
-            w.setLayout(tab)
-            self.macro_tab_w.append(w)
 
         self.lbl_memory = QLabel()
 
@@ -80,6 +71,16 @@ class MacroRecorder(BasicEditor):
         if not self.valid():
             return
         self.keyboard = self.device.keyboard
+
+        for x in range(self.keyboard.macro_count - len(self.macro_tab_w)):
+            tab = MacroTab(self, self.recorder is not None)
+            tab.changed.connect(self.on_change)
+            tab.record.connect(self.on_record)
+            tab.record_stop.connect(self.on_tab_stop)
+            self.macro_tabs.append(tab)
+            w = QWidget()
+            w.setLayout(tab)
+            self.macro_tab_w.append(w)
 
         # only show the number of macro editors that keyboard supports
         while self.tabs.count() > 0:


### PR DESCRIPTION
Moved the generation of the macro_tab_w to *rebuild()*
This was to be able to generate it `DYNAMIC_KEYMAP_MACRO_COUNT` big instead of a fixed 32

It has been tested with different macro_counts from 1 to 109.