### PR TITLE
Brazilian Keymap

### DIFF
--- a/src/main/python/keymap/brazilian.py
+++ b/src/main/python/keymap/brazilian.py
@@ -8,9 +8,12 @@ keymap = {
     "KC_LBRACKET": "`\n´",
     "KC_RBRACKET": "{\n[",
     "KC_BSLASH": "}\n]",
+    "KC_NONUS_HASH": "}\n]",
     "KC_NONUS_BSLASH": "|\n\\",
     "KC_RO": "?\n/",
     "KC_6": "¨\n6",
+    # On the ABNT2 the keypad comma and the keypad dot scancodes are switched
+    # (presumably because in Brazil comma is used as the decimal separator)
     "KC_KP_COMMA": ".",
     "KC_KP_DOT": ","
 }

--- a/src/main/python/keymap/brazilian.py
+++ b/src/main/python/keymap/brazilian.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+
+keymap = {
+    "KC_SCOLON": "Ç",
+    "KC_SLASH": ":\n;",
+    "KC_GRAVE": "\"\n'",
+    "KC_QUOTE": "^\n~",
+    "KC_LBRACKET": "`\n´",
+    "KC_RBRACKET": "{\n[",
+    "KC_BSLASH": "}\n]",
+    "KC_NONUS_BSLASH": "|\n\\",
+    "KC_RO": "?\n/",
+    "KC_6": "¨\n6",
+    "KC_KP_COMMA": ".",
+    "KC_KP_DOT": ","
+}

--- a/src/main/python/keymaps.py
+++ b/src/main/python/keymaps.py
@@ -1,8 +1,9 @@
 from keycodes import Keycode
-from keymap import danish, eurkey, french, german, hebrew, hungarian, latam, norwegian, russian, slovak, spanish, swedish, swedish_swerty, swiss
+from keymap import brazilian, danish, eurkey, french, german, hebrew, hungarian, latam, norwegian, russian, slovak, spanish, swedish, swedish_swerty, swiss
 
 KEYMAPS = [
     ("QWERTY", dict()),
+    ("Brazilian (QWERTY)", brazilian.keymap),
     ("Danish (QWERTY)", danish.keymap),
     ("EurKey (QWERTY)", eurkey.keymap),
     ("French (AZERTY)", french.keymap),


### PR DESCRIPTION
Adding Brazilian "ABNT2" keymap.
I could only test in windows, but this shouldn't have any OS specific issue, right?