### PR TITLE
Quick Toggle Key Override Layers

### DIFF
--- a/src/main/python/editor/key_override.py
+++ b/src/main/python/editor/key_override.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 from PyQt5 import QtCore
-from PyQt5.QtCore import pyqtSignal, QObject
-from PyQt5.QtWidgets import QWidget, QSizePolicy, QGridLayout, QVBoxLayout, QLabel, QCheckBox, QScrollArea, QFrame
+from PyQt5.QtCore import Qt, pyqtSignal, QObject
+from PyQt5.QtWidgets import QWidget, QSizePolicy, QGridLayout, QHBoxLayout, QVBoxLayout, QLabel, QCheckBox, QScrollArea, QFrame, QToolButton
 
 from protocol.constants import VIAL_PROTOCOL_DYNAMIC
-from util import make_scrollable
+from util import make_scrollable, tr
 from widgets.key_widget import KeyWidget
 from protocol.key_override import KeyOverrideOptions, KeyOverrideEntry
 from vial_device import VialKeyboard
@@ -117,13 +117,27 @@ class LayersUI(QWidget):
     def __init__(self):
         super().__init__()
         container = QGridLayout()
+        buttons = QHBoxLayout()
         self.layer_chks = [CheckBoxNoPadding(str(x)) for x in range(16)]
         for w in self.layer_chks:
             w.stateChanged.connect(self.on_change)
+        btn_all_layers = QToolButton()
+        btn_all_layers.setText(tr("KeyOverride", "Enable all"))
+        btn_all_layers.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        btn_no_layers = QToolButton()
+        btn_no_layers.setText(tr("KeyOverride", "Enable none"))
+        btn_no_layers.setToolButtonStyle(Qt.ToolButtonTextOnly)
+        btn_all_layers.clicked.connect(self.on_all_layers)
+        btn_no_layers.clicked.connect(self.on_no_layers)
 
         for x in range(8):
             container.addWidget(self.layer_chks[x], 0, x)
             container.addWidget(self.layer_chks[x + 8], 1, x)
+
+        buttons.addWidget(btn_all_layers)
+        buttons.addWidget(btn_no_layers)
+        buttons.addStretch()
+        container.addLayout(buttons, 2, 0, 1, -1)
 
         self.setLayout(container)
 
@@ -139,6 +153,14 @@ class LayersUI(QWidget):
 
     def on_change(self):
         self.changed.emit()
+
+    def on_all_layers(self):
+        for x, w in enumerate(self.layer_chks):
+            w.setChecked(True)
+
+    def on_no_layers(self):
+        for x, w in enumerate(self.layer_chks):
+            w.setChecked(False)
 
 
 class KeyOverrideEntryUI(QObject):

--- a/src/main/python/editor/key_override.py
+++ b/src/main/python/editor/key_override.py
@@ -127,8 +127,8 @@ class LayersUI(QWidget):
         btn_no_layers = QToolButton()
         btn_no_layers.setText(tr("KeyOverride", "Enable none"))
         btn_no_layers.setToolButtonStyle(Qt.ToolButtonTextOnly)
-        btn_all_layers.clicked.connect(self.on_all_layers)
-        btn_no_layers.clicked.connect(self.on_no_layers)
+        btn_all_layers.clicked.connect(self.on_enable_all_layers)
+        btn_no_layers.clicked.connect(self.on_disable_all_layers)
 
         for x in range(8):
             container.addWidget(self.layer_chks[x], 0, x)
@@ -154,11 +154,11 @@ class LayersUI(QWidget):
     def on_change(self):
         self.changed.emit()
 
-    def on_all_layers(self):
+    def on_enable_all_layers(self):
         for x, w in enumerate(self.layer_chks):
             w.setChecked(True)
 
-    def on_no_layers(self):
+    def on_disable_all_layers(self):
         for x, w in enumerate(self.layer_chks):
             w.setChecked(False)
 

--- a/src/main/python/editor/key_override.py
+++ b/src/main/python/editor/key_override.py
@@ -125,7 +125,7 @@ class LayersUI(QWidget):
         btn_all_layers.setText(tr("KeyOverride", "Enable all"))
         btn_all_layers.setToolButtonStyle(Qt.ToolButtonTextOnly)
         btn_no_layers = QToolButton()
-        btn_no_layers.setText(tr("KeyOverride", "Enable none"))
+        btn_no_layers.setText(tr("KeyOverride", "Disable all"))
         btn_no_layers.setToolButtonStyle(Qt.ToolButtonTextOnly)
         btn_all_layers.clicked.connect(self.on_enable_all_layers)
         btn_no_layers.clicked.connect(self.on_disable_all_layers)


### PR DESCRIPTION
I found it tedious when adding a Key Override to a single layer to have so go through and disable all the other layers. Reverting back to all layers was similarly fiddly.

To address this, small “Enable all” and “Enable none” buttons have been added beneath the list of layers to which a Key Override applies. Clicking the buttons will, as expected, enable or disable all the layer check boxes.

#### Screenshot

![Vial Key Override Layer Toggle Buttons](https://user-images.githubusercontent.com/69401250/218288741-e4d9c0ec-04ff-4c5e-94e0-0e85b4208ac5.png)

#### Testing

Tested that:

 * Clicking “Enable none“ deactivated all the “Enable on layers” checkboxes on the Key Override settings tab
 * Clicking “Enable all” activated all the “Enable on layers” checkboxes.
 * Checked that “Enable none“ had the expected behaviour on five layers of a keyboard
 * Checked that “Enable all“ had the expected behaviour on five layers of a keyboard