### PR TITLE
Add ability to create layer aliases in the json defs

### DIFF
--- a/src/main/python/editor/keymap_editor.py
+++ b/src/main/python/editor/keymap_editor.py
@@ -87,7 +87,12 @@ class KeymapEditor(BasicEditor):
 
         # create new layer labels
         for x in range(self.keyboard.layers):
-            btn = SquareButton(str(x))
+            lbl = str(x)
+            if lbl in self.keyboard.layer_labels:
+                lbl = self.keyboard.layer_labels[lbl]
+            btn = SquareButton(lbl)
+            width = btn.fontMetrics().boundingRect(lbl).width() + 18
+            btn.setMinimumWidth(width);
             btn.setFocusPolicy(Qt.NoFocus)
             btn.setRelSize(1.667)
             btn.setCheckable(True)

--- a/src/main/python/editor/keymap_editor.py
+++ b/src/main/python/editor/keymap_editor.py
@@ -88,8 +88,9 @@ class KeymapEditor(BasicEditor):
         # create new layer labels
         for x in range(self.keyboard.layers):
             lbl = str(x)
-            if lbl in self.keyboard.layer_labels:
-                lbl = self.keyboard.layer_labels[lbl]
+            if self.keyboard.layer_alias != None:
+                if lbl in self.keyboard.layer_alias:
+                    lbl = str(x)+": "+self.keyboard.layer_alias[lbl]
             btn = SquareButton(lbl)
             width = btn.fontMetrics().boundingRect(lbl).width() + 18
             btn.setMinimumWidth(width);

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -53,7 +53,7 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
         self.vibl = False
         self.custom_keycodes = None
         self.midi = None
-        self.layer_labels = None
+        self.layer_alias = None
 
         self.lighting_qmk_rgblight = self.lighting_qmk_backlight = self.lighting_vialrgb = False
 
@@ -185,7 +185,8 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
                 idx, opt = key.labels[8].split(",")
                 key.layout_index, key.layout_option = int(idx), int(opt)
 
-        self.layer_labels = payload["layers"]["alias"]
+        if "layer_alias" in payload:
+            self.layer_alias = payload["layer_alias"]
 
     def reload_keymap(self):
         """ Load current key mapping from the keyboard """

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -53,6 +53,7 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
         self.vibl = False
         self.custom_keycodes = None
         self.midi = None
+        self.layer_labels = None
 
         self.lighting_qmk_rgblight = self.lighting_qmk_backlight = self.lighting_vialrgb = False
 
@@ -183,6 +184,8 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
             if key.labels[8]:
                 idx, opt = key.labels[8].split(",")
                 key.layout_index, key.layout_option = int(idx), int(opt)
+
+        self.layer_labels = payload["layers"]["alias"]
 
     def reload_keymap(self):
         """ Load current key mapping from the keyboard """


### PR DESCRIPTION
This PR is my humble attempt at addressing the feature request first tabled here:

    https://feedback.vial.today/suggestions/325441/add-ability-to-create-layer-aliases-in-the-json-defs

The basics of it is this:  If a KB dev would like to create names / alias for thier layers, then they would add *(optionally)* the following structure to their keymap's `vial.json` file:

```json
    "layer_alias": {
        "0": "QWERTY",
        "1": "COLEMAK",
        "2": "DVORAK",
        "3": "LOWER",
        "4": "RAISE",
        "5": "PLOVER",
        "6": "ADJUST"
    }
```

For boards that leverage layers to drive independent functionality *(e.g. Planck [as above], or the Keychron fleet with their MacOS and Windows layers [as per suggestion site])* this would mean the world of less confusion by users who have not figured out layers yet.

***Caveat:*** I'm not a Py developer - this effort is a wild shot at trying to get this done.  Happy to take your recommendations on fixes, or just hand it over to you outright.