### PR TITLE
upgrade GH actions and runners to avoid breakage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,11 +101,12 @@ jobs:
       run: |
         . .\venv\Scripts\activate.ps1
         fbs freeze
+        Compress-Archive -Path "target\Vial" -DestinationPath vial-win.zip
 
     - uses: actions/upload-artifact@v3
       with:
         name: vial-win
-        path: target\Vial
+        path: vial-win.zip
 
     - name: Create installer
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.6.x'
 
@@ -35,19 +35,19 @@ jobs:
         ./pkg2appimage-*/pkg2appimage misc/Vial.yml
         mv out/Vial-*.AppImage out/Vial-x86_64.AppImage
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: vial-linux
         path: out/Vial-x86_64.AppImage
 
   build-mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     env:
       PYTHON_VERSION: 3.6.8
       MACOSX_DEPLOYMENT_TARGET: 10.9
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Get Python
       run: curl https://www.python.org/ftp/python/${PYTHON_VERSION}/python-${PYTHON_VERSION}-macosx${MACOSX_DEPLOYMENT_TARGET}.pkg -o "python.pkg"
@@ -71,7 +71,7 @@ jobs:
         fbs freeze
         hdiutil create -volname Vial -srcfolder "target/Vial.app" -ov -format UDZO vial-mac.dmg
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: vial-mac
         path: vial-mac.dmg
@@ -80,8 +80,8 @@ jobs:
     runs-on: windows-2019
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.6.x'
 
@@ -103,7 +103,7 @@ jobs:
         fbs freeze
         Compress-Archive -Path "target\Vial" -DestinationPath vial-win.zip
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: vial-win
         path: vial-win.zip
@@ -114,7 +114,7 @@ jobs:
         . .\venv\Scripts\activate.ps1
         fbs installer
 
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: vial-win-installer
         path: target\VialSetup.exe

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         path: out/Vial-x86_64.AppImage
 
   build-mac:
-    runs-on: macos-11
+    runs-on: macos-10.15
     env:
       PYTHON_VERSION: 3.6.8
       MACOSX_DEPLOYMENT_TARGET: 10.9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,12 +101,11 @@ jobs:
       run: |
         . .\venv\Scripts\activate.ps1
         fbs freeze
-        Compress-Archive -Path "target\Vial" -DestinationPath vial-win.zip
 
     - uses: actions/upload-artifact@v3
       with:
         name: vial-win
-        path: vial-win.zip
+        path: target\Vial
 
     - name: Create installer
       run: |


### PR DESCRIPTION
### Runners
- The macOS 10.15 runner is scheduled for complete removal on 2023-03-31. https://github.com/actions/runner-images/issues/5583#issuecomment-1426004850
- While removal is TBA, the Ubuntu runner will drop out of support soon too: https://github.com/actions/runner-images/issues/6002

### Actions
- The `set-output` command used by `setup-python@v1` will be disabled on 2023-05-31. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- All actions are scheduled for migration to Node 16 by "Summer 2023". https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

P.S. I am able to confirm that the portable versions build and launch as expected on Windows 10 and Arch Linux. The macOS zip has a dmg in it, but I can't check anything more deeply than that. I wouldn't target `main` with this, but there are no other more-appropriate branches available.