### PR TITLE
fix: encoders, macro rendering, some keycode handling

### DIFF
--- a/src/main/python/editor/keymap_editor.py
+++ b/src/main/python/editor/keymap_editor.py
@@ -7,7 +7,7 @@ from PyQt5.QtCore import Qt, pyqtSignal
 from any_keycode_dialog import AnyKeycodeDialog
 from editor.basic_editor import BasicEditor
 from widgets.keyboard_widget import KeyboardWidget, EncoderWidget
-from keycodes.keycodes import recreate_keyboard_keycodes, BASIC_KEYCODES, Keycode
+from keycodes.keycodes import recreate_keyboard_keycodes, Keycode
 from widgets.square_button import SquareButton
 from tabbed_keycodes import TabbedKeycodes, keycode_filter_masked
 from util import tr, KeycodeDisplay
@@ -208,7 +208,7 @@ class KeymapEditor(BasicEditor):
 
         # if masked, ensure that this is a byte-sized keycode
         if self.container.active_mask:
-            if Keycode.deserialize(keycode) > 0x00FF:
+            if not Keycode.is_basic(keycode):
                 return
             kc = Keycode.find_outer_keycode(self.keyboard.encoder_layout[(l, i, d)])
             if kc is None:
@@ -224,7 +224,7 @@ class KeymapEditor(BasicEditor):
         if r >= 0 and c >= 0:
             # if masked, ensure that this is a byte-sized keycode
             if self.container.active_mask:
-                if Keycode.deserialize(keycode) > 0x00FF:
+                if not Keycode.is_basic(keycode):
                     return
                 kc = Keycode.find_outer_keycode(self.keyboard.layout[(l, r, c)])
                 if kc is None:

--- a/src/main/python/editor/keymap_editor.py
+++ b/src/main/python/editor/keymap_editor.py
@@ -207,7 +207,7 @@ class KeymapEditor(BasicEditor):
 
         # if masked, ensure that this is a byte-sized keycode
         if self.container.active_mask:
-            if keycode not in BASIC_KEYCODES:
+            if Keycode.deserialize(keycode) > 0x00FF:
                 return
             kc = Keycode.find_outer_keycode(self.keyboard.encoder_layout[(l, i, d)])
             if kc is None:

--- a/src/main/python/editor/keymap_editor.py
+++ b/src/main/python/editor/keymap_editor.py
@@ -150,7 +150,8 @@ class KeymapEditor(BasicEditor):
             return
         current_code = self.code_for_widget(self.container.active_key)
         if self.container.active_mask:
-            current_code &= 0xFF
+            kc = Keycode.find_inner_keycode(current_code)
+            current_code = kc.qmk_id
 
         self.dlg = AnyKeycodeDialog(current_code)
         self.dlg.finished.connect(self.on_dlg_finished)
@@ -223,7 +224,7 @@ class KeymapEditor(BasicEditor):
         if r >= 0 and c >= 0:
             # if masked, ensure that this is a byte-sized keycode
             if self.container.active_mask:
-                if keycode not in BASIC_KEYCODES:
+                if Keycode.deserialize(keycode) > 0x00FF:
                     return
                 kc = Keycode.find_outer_keycode(self.keyboard.layout[(l, r, c)])
                 if kc is None:

--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -45,11 +45,11 @@ class Keycode:
             self.masked_keycodes.add(qmk_id.replace("(kc)", ""))
 
     @classmethod
-    def find(cls, code):
+    def find(cls, qmk_id):
         # this is to handle cases of qmk_id LCTL(kc) propagated here from find_inner_keycode
-        if code == "kc":
-            code = "KC_NO"
-        return KEYCODES_MAP.get(code)
+        if qmk_id == "kc":
+            qmk_id = "KC_NO"
+        return KEYCODES_MAP.get(qmk_id)
 
     @classmethod
     def find_outer_keycode(cls, qmk_id):
@@ -82,6 +82,10 @@ class Keycode:
         return "(" in qmk_id and qmk_id[:qmk_id.find("(")] in cls.masked_keycodes
 
     @classmethod
+    def is_basic(cls, qmk_id):
+        return cls.deserialize(qmk_id) < 0x00FF
+
+    @classmethod
     def label(cls, qmk_id):
         keycode = cls.find_outer_keycode(qmk_id)
         if keycode is None:
@@ -112,7 +116,7 @@ class Keycode:
                 return kc.qmk_id
         else:
             outer = RAWCODES_MAP.get(code & 0xFF00)
-            inner = RAWCODES_MAP.get(code & 0xFF)
+            inner = RAWCODES_MAP.get(code & 0x00FF)
             if outer is not None and inner is not None:
                 return outer.qmk_id.replace("kc", inner.qmk_id)
         return hex(code)

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -210,8 +210,8 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
             for idx in self.encoderpos:
                 data = self.usb_send(self.dev, struct.pack("BBBB", CMD_VIA_VIAL_PREFIX, CMD_VIAL_GET_ENCODER, layer, idx),
                                      retries=20)
-                self.encoder_layout[(layer, idx, 0)] = struct.unpack(">H", data[0:2])[0]
-                self.encoder_layout[(layer, idx, 1)] = struct.unpack(">H", data[2:4])[0]
+                self.encoder_layout[(layer, idx, 0)] = Keycode.serialize(struct.unpack(">H", data[0:2])[0])
+                self.encoder_layout[(layer, idx, 1)] = Keycode.serialize(struct.unpack(">H", data[2:4])[0])
 
         if self.layout_labels:
             data = self.usb_send(self.dev, struct.pack("BB", CMD_VIA_GET_KEYBOARD_VALUE, VIA_LAYOUT_OPTIONS),
@@ -312,16 +312,13 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
             self.layout[key] = code
 
     def set_encoder(self, layer, index, direction, code):
-        if code < 0:
-            return
-
         key = (layer, index, direction)
         if self.encoder_layout[key] != code:
             if code == RESET_KEYCODE:
                 Unlocker.unlock(self)
 
             self.usb_send(self.dev, struct.pack(">BBBBBH", CMD_VIA_VIAL_PREFIX, CMD_VIAL_SET_ENCODER,
-                                                layer, index, direction, code), retries=20)
+                                                layer, index, direction, Keycode.deserialize(code)), retries=20)
             self.encoder_layout[key] = code
 
     def set_layout_options(self, options):

--- a/src/main/python/protocol/macro.py
+++ b/src/main/python/protocol/macro.py
@@ -116,19 +116,21 @@ def macro_deserialize_v2(data):
                 sequence.append(ch)
             data.pop(0)
     for s in sequence:
+
         if isinstance(s, str):
             out.append(ActionText(s))
         else:
             args = None
             if s[0] in [SS_TAP_CODE, SS_DOWN_CODE, SS_UP_CODE]:
                 args = s[1]
+                if args is not None:
+                    args = [Keycode.serialize(kc) for kc in args]
             elif s[0] == SS_DELAY_CODE:
                 args = s[1]
 
             if args is not None:
                 cls = {SS_TAP_CODE: ActionTap, SS_DOWN_CODE: ActionDown, SS_UP_CODE: ActionUp,
                        SS_DELAY_CODE: ActionDelay}[s[0]]
-                args = [Keycode.serialize(kc) for kc in args]
                 out.append(cls(args))
     return out
 

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -34,7 +34,7 @@ class AlternativeDisplay(QWidget):
                 btn = SquareButton()
                 btn.setRelSize(KEYCODE_BTN_RATIO)
                 btn.setText(title)
-                btn.clicked.connect(lambda st, k=code: self.keycode_changed.emit(k))
+                btn.clicked.connect(lambda st, k=code: self.keycode_changed.emit(title))
                 self.key_layout.addWidget(btn)
 
         layout = QVBoxLayout()
@@ -191,7 +191,7 @@ class FilteredTabbedKeycodes(QTabWidget):
         KeycodeDisplay.notify_keymap_override(self)
 
     def on_keycode_changed(self, code):
-        if code == -1:
+        if code == "Any":
             self.anykey.emit()
         else:
             self.keycode_changed.emit(code)

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -145,7 +145,7 @@ def keycode_filter_any(kc):
 
 
 def keycode_filter_masked(kc):
-    return kc in BASIC_KEYCODES
+    return Keycode.is_basic(kc)
 
 
 class FilteredTabbedKeycodes(QTabWidget):

--- a/src/main/python/widgets/key_widget.py
+++ b/src/main/python/widgets/key_widget.py
@@ -1,5 +1,6 @@
 from PyQt5.QtCore import pyqtSignal
 
+from keycodes.keycodes import Keycode
 from any_keycode_dialog import AnyKeycodeDialog
 from widgets.keyboard_widget import KeyboardWidget
 from kle_serial import Key
@@ -52,15 +53,18 @@ class KeyWidget(KeyboardWidget):
         """ Unlike set_keycode, this handles setting masked keycode inside the mask """
 
         if self.active_mask:
-            if keycode > 0xFF:
+            if Keycode.deserialize(keycode) > 0x00FF:
                 return
-            keycode = (self.keycode & 0xFF00) | keycode
+            kc = Keycode.find_outer_keycode(self.keycode)
+            if kc is None:
+                return
+            keycode = kc.qmk_id.replace("(kc)", "({})".format(keycode))
         self.set_keycode(keycode)
 
     def on_anykey(self):
         if self.active_key is None:
             return
-        self.dlg = AnyKeycodeDialog((self.keycode & 0xFF) if self.active_mask else self.keycode)
+        self.dlg = AnyKeycodeDialog(Keycode.find_inner_keycode(self.keycode) if self.active_mask else self.keycode)
         self.dlg.finished.connect(self.on_dlg_finished)
         self.dlg.setModal(True)
         self.dlg.show()

--- a/src/main/python/widgets/key_widget.py
+++ b/src/main/python/widgets/key_widget.py
@@ -53,7 +53,7 @@ class KeyWidget(KeyboardWidget):
         """ Unlike set_keycode, this handles setting masked keycode inside the mask """
 
         if self.active_mask:
-            if Keycode.deserialize(keycode) > 0x00FF:
+            if not Keycode.is_basic(keycode):
                 return
             kc = Keycode.find_outer_keycode(self.keycode)
             if kc is None:

--- a/src/main/python/widgets/key_widget.py
+++ b/src/main/python/widgets/key_widget.py
@@ -64,7 +64,11 @@ class KeyWidget(KeyboardWidget):
     def on_anykey(self):
         if self.active_key is None:
             return
-        self.dlg = AnyKeycodeDialog(Keycode.find_inner_keycode(self.keycode) if self.active_mask else self.keycode)
+        if self.active_mask:
+            kc = Keycode.find_inner_keycode(self.keycode).qmk_id
+        else:
+            kc = self.keycode
+        self.dlg = AnyKeycodeDialog(kc)
         self.dlg.finished.connect(self.on_dlg_finished)
         self.dlg.setModal(True)
         self.dlg.show()


### PR DESCRIPTION
Issues resolved:
- Boards with encoders throw errors and can't be mapped
- `Any` throws errors if you try to assign it from the keycode list (double-clicking a key in the keyboard layout works)
- Nested keycodes cannot be assigned in non-layout pages (e.g. combos)
- Macros with delays weren't being deserialized correctly (It felt very dumb to open up a separate PR for basically one line.)