### PR TITLE
refactor: deliberately round "Stop recording" x position

### DIFF
--- a/src/main/python/macro/macro_recorder_linux.py
+++ b/src/main/python/macro/macro_recorder_linux.py
@@ -36,7 +36,7 @@ class LinuxRecorder(QWidget):
         self.show()
 
         center = QApplication.desktop().availableGeometry(self).center()
-        self.move(center.x() - self.width() * 0.5, 0)
+        self.move(round(center.x() - self.width() * 0.5), 0)
 
         args = [sys.executable]
         if os.getenv("APPIMAGE"):

--- a/src/main/python/macro/macro_recorder_windows.py
+++ b/src/main/python/macro/macro_recorder_windows.py
@@ -41,7 +41,7 @@ class WindowsRecorder(QWidget):
         self.show()
 
         center = QApplication.desktop().availableGeometry(self).center()
-        self.move(center.x() - self.width() * 0.5, 0)
+        self.move(round(center.x() - self.width() * 0.5), 0)
 
         keyboard.hook(self.on_key)
 


### PR DESCRIPTION
`QtWidget.move()` expects integers when called with x and y coordinates. I'm not sure what changed from Python 3.6 and Qt 5.9 to Python 3.10 and Qt 5.15, but forcibly rounding here works regardless of version.

![image](https://user-images.githubusercontent.com/86894501/236364609-b89c09d9-222a-45d2-9b1b-583ecf431495.png)