### PR TITLE
feat: improvements to main window

### DIFF
--- a/src/main/python/main.py
+++ b/src/main/python/main.py
@@ -9,7 +9,9 @@ if ssl.get_default_verify_paths().cafile is None:
 import traceback
 
 from PyQt5 import QtWidgets, QtCore
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QSettings
+
+from fbs_runtime.application_context import cached_property
 from fbs_runtime.application_context.PyQt5 import ApplicationContext
 
 import sys
@@ -53,6 +55,21 @@ class UncaughtHook(QtCore.QObject):
             self._exception_caught.emit(log_msg)
         sys._excepthook(exc_type, exc_value, exc_traceback)
 
+class VialApplicationContext(ApplicationContext):
+    @cached_property
+    def app(self):
+        # Override the app definition in order to set WM_CLASS.
+        result = QtWidgets.QApplication(sys.argv)
+        result.setApplicationName(self.build_settings["app_name"])
+        result.setOrganizationName(self.build_settings["app_name"])
+        result.setOrganizationDomain("vial.today")
+
+        #TODO: Qt sets applicationVersion on non-Linux platforms if the exe/pkg metadata is correctly configured.
+        # https://doc.qt.io/qt-5/qcoreapplication.html#applicationVersion-prop
+        # Verify it is, and only set manually on Linux.
+        #if sys.platform.startswith("linux"):
+        result.setApplicationVersion(self.build_settings["version"])
+        return result
 
 if __name__ == '__main__':
     if len(sys.argv) == 2 and sys.argv[1] == "--linux-recorder":
@@ -60,7 +77,7 @@ if __name__ == '__main__':
 
         linux_keystroke_recorder()
     else:
-        appctxt = ApplicationContext()       # 1. Instantiate ApplicationContext
+        appctxt = VialApplicationContext()       # 1. Instantiate ApplicationContext
         init_logger()
         qt_exception_hook = UncaughtHook()
         window = MainWindow(appctxt)

--- a/src/main/python/main_window.py
+++ b/src/main/python/main_window.py
@@ -3,7 +3,7 @@ import logging
 import platform
 from json import JSONDecodeError
 
-from PyQt5.QtCore import Qt, QSettings, QStandardPaths, QTimer, QT_VERSION_STR
+from PyQt5.QtCore import Qt, QSettings, QStandardPaths, QTimer, QRect, QT_VERSION_STR
 from PyQt5.QtWidgets import QWidget, QComboBox, QToolButton, QHBoxLayout, QVBoxLayout, QMainWindow, QAction, qApp, \
     QFileDialog, QDialog, QTabWidget, QActionGroup, QMessageBox, QLabel
 
@@ -42,12 +42,18 @@ class MainWindow(QMainWindow):
 
         self.ui_lock_count = 0
 
-        self.settings = QSettings("Vial", "Vial")
-        if self.settings.value("size", None) and self.settings.value("pos", None):
+        self.settings = QSettings()
+        if self.settings.value("size", None):
             self.resize(self.settings.value("size"))
-            self.move(self.settings.value("pos"))
         else:
             self.resize(WINDOW_WIDTH, WINDOW_HEIGHT)
+
+        _pos = self.settings.value("pos", None)
+        # NOTE: QDesktopWidget is obsolete, but QApplication.screenAt only usable in Qt 5.10+
+        if _pos and qApp.desktop().geometry().contains(QRect(_pos, self.size())):
+        #if _pos and qApp.screenAt(_pos) and qApp.screenAt(_pos + (self.rect().bottomRight())):
+            self.move(self.settings.value("pos"))
+
         themes.Theme.set_theme(self.get_theme())
 
         self.combobox_devices = QComboBox()
@@ -158,7 +164,7 @@ class MainWindow(QMainWindow):
 
         exit_act = QAction(tr("MenuFile", "Exit"), self)
         exit_act.setShortcut("Ctrl+Q")
-        exit_act.triggered.connect(qApp.exit)
+        exit_act.triggered.connect(self.close)
 
         if sys.platform != "emscripten":
             file_menu = self.menuBar().addMenu(tr("Menu", "File"))
@@ -408,7 +414,7 @@ class MainWindow(QMainWindow):
         text = 'Vial {}<br><br>Python {}<br>Qt {}<br><br>' \
                'Licensed under the terms of the<br>GNU General Public License (version 2 or later)<br><br>' \
                '<a href="https://get.vial.today/">https://get.vial.today/</a>' \
-               .format(self.appctx.build_settings["version"],
+               .format(qApp.applicationVersion(),
                        platform.python_version(), QT_VERSION_STR)
 
         if sys.platform == "emscripten":


### PR DESCRIPTION
- Sets `WM_CLASS` for the application. This attribute gives various X window managers (bspwm, i3, etc) more out of the box control over how windows display. Subclassing `ApplicationContext` might seem like overkill, but given the `@cached_property` decorator in `fbs` I don't think there's another way. (Yes, `appctx.app.setApplicationName()` was the first thing I tried.)

- [This is also where `applicationVersion` is set](https://github.com/mherrmann/fbs/blob/702761412a2c8617e68ea8c398f7df725ef71a79/fbs_runtime/application_context/__init__.py#L55), so to further reduce the surface area exposed to `fbs`, the `build_settings` lookup in `main_window.py` was replaced with Qt's standard attribute.

- Closes #175: when re-opening Vial, checks that no part of the application would be offscreen before moving the window to its previously-saved position.

- Calling `QApplication.exit()` doesn't trigger `QMainWindow.closeEvent()`, which meant the size and position of the main window weren't saved if the application was exited via menu or keyboard shortcut. Maybe you want to hook into [`QGuiApplication.lastWindowClosed()`](https://doc.qt.io/qt-5/qguiapplication.html#lastWindowClosed) instead, but at this point I'm not seeing much difference. Feel free to tell me how I'm wrong.

If recent additions to `main` will be merged into the `new-keycodes` branch in the very near future, I'll be happy to cherry-pick and retarget.