### PR TITLE
keymap: add JIS (japanese) keymap

### DIFF
--- a/src/main/python/keymap/japanese.py
+++ b/src/main/python/keymap/japanese.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+keymap = {
+    "KC_LBRACKET": "`\n@",
+    "KC_RBRACKET": "{\n[",
+    "KC_2": "\"\n2",
+    "KC_6": "&\n6",
+    "KC_7": "'\n7",
+    "KC_8": "(\n8",
+    "KC_9": ")\n9",
+    "KC_0": "\n0",
+    "KC_MINUS": "=\n-",
+    "KC_EQUAL": "~\n^",
+    "KC_SCOLON": "+\n;",
+    "KC_QUOTE": "*\n:",
+    "KC_NONUS_HASH": "}\n]",
+    "KC_GRAVE": "HAN/\nZEN",
+    "KC_KP_DOT": ","
+}

--- a/src/main/python/keymaps.py
+++ b/src/main/python/keymaps.py
@@ -1,5 +1,5 @@
 from keycodes.keycodes import Keycode
-from keymap import brazilian, canadian_csa, danish, eurkey, french, german, hebrew, hungarian, latam, norwegian, russian, slovak, spanish, swedish, swedish_swerty, swiss
+from keymap import brazilian, canadian_csa, danish, eurkey, french, german, hebrew, hungarian, japanese, latam, norwegian, russian, slovak, spanish, swedish, swedish_swerty, swiss
 
 KEYMAPS = [
     ("QWERTY", dict()),
@@ -12,6 +12,7 @@ KEYMAPS = [
     ("German (QWERTZ)", german.keymap),
     ("Hebrew (Standard)", hebrew.keymap),
     ("Hungarian (QWERTZ)", hungarian.keymap),
+    ("Japanese (QWERTY)", japanese.keymap),
     ("Latin American (QWERTY)", latam.keymap),
     ("Norwegian (QWERTY)", norwegian.keymap),
     ("Russian (ЙЦУКЕН)", russian.keymap),


### PR DESCRIPTION
This PR adds JIS layouts for Japanese.

https://en.wikipedia.org/wiki/Keyboard_layout#Japanese

![image](https://github.com/vial-kb/vial-gui/assets/9251039/3cc5c32d-80ad-4837-a268-f666ffdce319)
