### PR TITLE
Add support for JSON without LZMA compression

### DIFF
--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -139,7 +139,12 @@ class Keyboard(ProtocolMacro, ProtocolDynamic, ProtocolTapDance, ProtocolCombo, 
                 block += 1
                 sz -= MSG_LEN
 
-            payload = json.loads(lzma.decompress(payload))
+            try:
+                payload = lzma.decompress(payload)
+            except lzma.LZMAError:
+                payload = payload.decode()
+
+            payload = json.loads(payload)
 
         self.check_protocol_version()
 


### PR DESCRIPTION
This PR adds support for JSON that is not LZMA compressed.
Of course, JSON that is already LZMA compressed will continue to be supported as well.


This PR addresses the items mentioned in the message below.
https://discord.com/channels/798171334756401183/798171873951219754/1168882445446283324