### PR TITLE
More custom keycodes (from 64 to 256)

### DIFF
--- a/src/main/python/keycodes/keycodes_v6.py
+++ b/src/main/python/keycodes/keycodes_v6.py
@@ -575,7 +575,7 @@ for x in range(32):
 for x in range(16):
     keycodes_v6.kc["LT{}(kc)".format(x)] = keycodes_v6.kc["QK_LAYER_TAP"] | (((x) & 0xF) << 8)
 
-for x in range(64):
+for x in range(256):
     keycodes_v6.kc["USER{:02}".format(x)] = keycodes_v6.kc["QK_KB"] + x
 
 for name, val in keycodes_v6.kc.items():


### PR DESCRIPTION
You need a lot of "midi_send_cc" if you use things like MIDI2LR to control Adobe Lightroom