### PR TITLE
Don't sort keys

### DIFF
--- a/src/main/python/widgets/keyboard_widget.py
+++ b/src/main/python/widgets/keyboard_widget.py
@@ -344,8 +344,6 @@ class KeyboardWidget(QWidget):
         self.place_widgets()
         self.widgets = list(filter(lambda w: not w.desc.decal, self.widgets))
 
-        self.widgets.sort(key=lambda w: (w.y, w.x))
-
         # determine maximum width and height of container
         max_w = max_h = 0
         for key in self.widgets:


### PR DESCRIPTION
I have keyboard with layout like this.

![image](https://github.com/vial-kb/vial-gui/assets/12847693/4515892b-c467-4320-ab00-57662dcfa505)

Vial sorts keys buy its coordinate x and y, and method `select_next` jumps to nearly random key.

May be we can safely remove this feature?