### PR TITLE
Restore whether the window was maximized in the last run

### DIFF
--- a/src/main/python/main_window.py
+++ b/src/main/python/main_window.py
@@ -54,6 +54,9 @@ class MainWindow(QMainWindow):
         #if _pos and qApp.screenAt(_pos) and qApp.screenAt(_pos + (self.rect().bottomRight())):
             self.move(self.settings.value("pos"))
 
+        if self.settings.value("maximized", False, bool):
+            self.showMaximized()
+
         themes.Theme.set_theme(self.get_theme())
 
         self.combobox_devices = QComboBox()
@@ -434,5 +437,6 @@ class MainWindow(QMainWindow):
     def closeEvent(self, e):
         self.settings.setValue("size", self.size())
         self.settings.setValue("pos", self.pos())
+        self.settings.setValue("maximized", self.isMaximized())
 
         e.accept()


### PR DESCRIPTION
This improves the user experience when the window was maximized during the last run (tested on Windows)