### PR TITLE
Write application version to registry for Windows installer

### DIFF
--- a/src/installer/windows/Installer.nsi
+++ b/src/installer/windows/Installer.nsi
@@ -80,6 +80,7 @@ Section
   ${GetSize} "$InstDir" "/S=0K" $0 $1 $2
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD SHCTX "${UNINST_KEY}" "EstimatedSize" "$0"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "${VERSION}"
 
 SectionEnd
 

--- a/src/installer/windows/Installer.nsi
+++ b/src/installer/windows/Installer.nsi
@@ -80,7 +80,7 @@ Section
   ${GetSize} "$InstDir" "/S=0K" $0 $1 $2
   IntFmt $0 "0x%08X" $0
   WriteRegDWORD SHCTX "${UNINST_KEY}" "EstimatedSize" "$0"
-  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "${VERSION}"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "${version}"
 
 SectionEnd
 


### PR DESCRIPTION
Write the application version to the registry during installation on Windows, which will be displayed in the "Apps" in Settings or "Apps & Features" in Control Panel.

![Apps & Features](https://github.com/user-attachments/assets/51108df1-a00e-409a-9493-bd84e1944eb5)
