### PR TITLE
Increased user keycodes limit in keycodes_v5

### DIFF
--- a/src/main/python/keycodes/keycodes_v5.py
+++ b/src/main/python/keycodes/keycodes_v5.py
@@ -594,7 +594,8 @@ for x in range(32):
 for x in range(16):
     keycodes_v5.kc["LT{}(kc)".format(x)] = keycodes_v5.kc["QK_LAYER_TAP"] | (((x) & 0xF) << 8)
 
-for x in range(16):
+#TODO(userkeycodes): temp workaround, keycodes handling is messy, rework this later
+for x in range(64):
     keycodes_v5.kc["USER{:02}".format(x)] = keycodes_v5.kc["QK_KB"] + x
 
 for name, val in keycodes_v5.kc.items():


### PR DESCRIPTION
From vial-kb/vial-gui#318

Same change in v6 copied over to v5 keycodes script, this prevents a similar crash that would still happen sometimes if it's using the v5 version.

Also added a TODO comment about it.