### PR TITLE
Update Quantum Keycodes

### DIFF
--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -329,8 +329,8 @@ KEYCODES_LAYERS = []
 RESET_KEYCODE = "QK_BOOT"
 
 KEYCODES_BOOT = [
-    K("QK_BOOT", "Boot-\nloader", "Put the keyboard into bootloader mode for flashing"),
-    K("QK_REBOOT", "Reboot", "Resets the keyboard. Does not load the bootloader"),
+    K("QK_BOOT", "Boot-\nloader", "Put the keyboard into bootloader mode for flashing", alias=["RESET"]),
+    K("QK_REBOOT", "Reboot", "Reboots the keyboard. Does not load the bootloader"),
     K("QK_CLEAR_EEPROM", "Clear\nEEPROM", "Reinitializes the keyboard's EEPROM (persistent memory)", alias=["EE_CLR"]),
 ]
 

--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -326,10 +326,12 @@ KEYCODES_ISO_KR = [
 KEYCODES_ISO.extend(KEYCODES_ISO_KR)
 
 KEYCODES_LAYERS = []
-RESET_KEYCODE = "RESET"
+RESET_KEYCODE = "QK_BOOT"
 
 KEYCODES_BOOT = [
-    K("RESET", "Reset", "Reboot to bootloader")
+    K("QK_BOOT", "Boot-\nloader", "Put the keyboard into bootloader mode for flashing"),
+    K("QK_REBOOT", "Reboot", "Resets the keyboard. Does not load the bootloader"),
+    K("QK_CLEAR_EEPROM", "Clear\nEEPROM", "Reinitializes the keyboard's EEPROM (persistent memory)", alias=["EE_CLR"]),
 ]
 
 KEYCODES_MODIFIERS = [

--- a/src/main/python/keycodes/keycodes_v5.py
+++ b/src/main/python/keycodes/keycodes_v5.py
@@ -548,7 +548,8 @@ class keycodes_v5:
         "MI_BENDD": 0x5CB9,
         "MI_BENDU": 0x5CBA,
 
-        "RESET": 0x5C00,
+        "QK_BOOT": 0x5C00,
+        "QK_CLEAR_EEPROM": 0x5CDF,
 
         "FN_MO13": 0x5F10,
         "FN_MO23": 0x5F11,
@@ -574,6 +575,7 @@ class keycodes_v5:
         "RM_VALD": 0x999a,
         "RM_SPDU": 0x999b,
         "RM_SPDD": 0x999c,
+        "QK_REBOOT": 0x999d,
     }
 
     masked = set()

--- a/src/main/python/keycodes/keycodes_v6.py
+++ b/src/main/python/keycodes/keycodes_v6.py
@@ -549,7 +549,9 @@ class keycodes_v6:
         "MI_BENDD": 0x718E,
         "MI_BENDU": 0x718F,
 
-        "RESET": 0x7C00,
+        "QK_BOOT": 0x7C00,
+        "QK_REBOOT": 0x7C01,
+        "QK_CLEAR_EEPROM": 0x7C03,
 
         "FN_MO13": 0x7C77,
         "FN_MO23": 0x7C78,


### PR DESCRIPTION
Renames `RESET`/`QK_BOOT` to `Bootloader`, adds `Reboot`/`QK_REBOOT` and `Clear EEPROM`/`QK_CLEAR_EEPROM`

![image](https://github.com/user-attachments/assets/15f220c3-9758-45c1-8672-9a27ae311a53)
