### PR TITLE
PDF(layer), Caps Word, and Layer Lock for vial-gui.

### DIFF
--- a/src/main/python/about_keyboard.py
+++ b/src/main/python/about_keyboard.py
@@ -2,7 +2,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout, QLabel, QPlainTextEdit
 
 from protocol.constants import VIAL_PROTOCOL_DYNAMIC, VIAL_PROTOCOL_KEY_OVERRIDE, VIAL_PROTOCOL_ADVANCED_MACROS, \
-    VIAL_PROTOCOL_EXT_MACROS, VIAL_PROTOCOL_QMK_SETTINGS, VIAL_PROTOCOL_OPTIONAL_FEATURES
+    VIAL_PROTOCOL_EXT_MACROS, VIAL_PROTOCOL_QMK_SETTINGS
 
 
 class AboutKeyboard(QDialog):
@@ -51,7 +51,7 @@ class AboutKeyboard(QDialog):
     def about_feature(self, feature_name):
         if feature_name in self.keyboard.supported_features:
             return "yes"
-        return self.want_min_vial_fw(VIAL_PROTOCOL_OPTIONAL_FEATURES)
+        return self.want_min_vial_fw(VIAL_PROTOCOL_DYNAMIC)
 
     def __init__(self, device):
         super().__init__()

--- a/src/main/python/about_keyboard.py
+++ b/src/main/python/about_keyboard.py
@@ -2,7 +2,7 @@ from PyQt5.QtGui import QFont
 from PyQt5.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout, QLabel, QPlainTextEdit
 
 from protocol.constants import VIAL_PROTOCOL_DYNAMIC, VIAL_PROTOCOL_KEY_OVERRIDE, VIAL_PROTOCOL_ADVANCED_MACROS, \
-    VIAL_PROTOCOL_EXT_MACROS, VIAL_PROTOCOL_QMK_SETTINGS
+    VIAL_PROTOCOL_EXT_MACROS, VIAL_PROTOCOL_QMK_SETTINGS, VIAL_PROTOCOL_OPTIONAL_FEATURES
 
 
 class AboutKeyboard(QDialog):
@@ -48,6 +48,11 @@ class AboutKeyboard(QDialog):
             return "yes"
         return self.want_min_vial_fw(VIAL_PROTOCOL_QMK_SETTINGS)
 
+    def about_feature(self, feature_name):
+        if feature_name in self.keyboard.supported_features:
+            return "yes"
+        return self.want_min_vial_fw(VIAL_PROTOCOL_OPTIONAL_FEATURES)
+
     def __init__(self, device):
         super().__init__()
 
@@ -82,6 +87,8 @@ class AboutKeyboard(QDialog):
         text += "Tap Dance entries: {}\n".format(self.about_tap_dance())
         text += "Combo entries: {}\n".format(self.about_combo())
         text += "Key Override entries: {}\n".format(self.about_key_override())
+        text += "Caps Word: {}\n".format(self.about_feature("caps_word"))
+        text += "Layer Lock: {}\n".format(self.about_feature("layer_lock"))
         text += "\n"
 
         text += "QMK Settings: {}\n".format(self.about_qmk_settings())

--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -14,6 +14,7 @@ class Keycode:
     recorder_alias_to_keycode = dict()
     qmk_id_to_keycode = dict()
     protocol = 0
+    hidden = False
 
     def __init__(self, qmk_id, label, tooltip=None, masked=False, printable=None, recorder_alias=None, alias=None, requires_feature=None):
         self.qmk_id = qmk_id
@@ -919,8 +920,10 @@ def recreate_keyboard_keycodes(keyboard):
 
     recreate_keycodes()
 
-    # Keep only keycodes where .requires_feature is supported by the keyboard.
-    KEYCODES[:] = list(filter(lambda kc: kc.is_supported_by(keyboard), KEYCODES))
+    # Hide keycodes where .requires_feature isn't supported by the keyboard.
+    for kc in KEYCODES:
+        if not kc.is_supported_by(keyboard):
+            kc.hidden = True
 
 
 recreate_keycodes()

--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -922,8 +922,7 @@ def recreate_keyboard_keycodes(keyboard):
 
     # Hide keycodes where .requires_feature isn't supported by the keyboard.
     for kc in KEYCODES:
-        if not kc.is_supported_by(keyboard):
-            kc.hidden = True
+        kc.hidden = not kc.is_supported_by(keyboard)
 
 
 recreate_keycodes()

--- a/src/main/python/keycodes/keycodes.py
+++ b/src/main/python/keycodes/keycodes.py
@@ -15,9 +15,10 @@ class Keycode:
     qmk_id_to_keycode = dict()
     protocol = 0
 
-    def __init__(self, qmk_id, label, tooltip=None, masked=False, printable=None, recorder_alias=None, alias=None):
+    def __init__(self, qmk_id, label, tooltip=None, masked=False, printable=None, recorder_alias=None, alias=None, requires_feature=None):
         self.qmk_id = qmk_id
         self.qmk_id_to_keycode[qmk_id] = self
+        self.requires_feature = requires_feature
         self.label = label
         # we cannot embed full CJK fonts due to large size, workaround like this for now
         if sys.platform == "emscripten" and not label.isascii() and qmk_id != "KC_TRNS":
@@ -156,6 +157,12 @@ class Keycode:
         if qmk_constant not in kc:
             raise RuntimeError("unable to resolve qmk_id={}".format(qmk_constant))
         return kc[qmk_constant]
+
+    def is_supported_by(self, keyboard):
+      """ Whether the keycode is supported by the keyboard. """
+      if self.requires_feature is None:
+        return True
+      return self.requires_feature in keyboard.supported_features
 
 
 K = Keycode
@@ -482,6 +489,8 @@ KEYCODES_QUANTUM = [
     K("CMB_ON", "Combo\nOn", "Turns on Combo feature"),
     K("CMB_OFF", "Combo\nOff", "Turns off Combo feature"),
     K("CMB_TOG", "Combo\nToggle", "Toggles Combo feature on and off"),
+
+    K("QK_CAPS_WORD_TOGGLE", "Caps\nWord", "Capitalizes until end of current word", alias=["CW_TOGG"], requires_feature="caps_word"),
 ]
 
 KEYCODES_BACKLIGHT = [
@@ -845,14 +854,16 @@ def recreate_keyboard_keycodes(keyboard):
 
     layers = keyboard.layers
 
-    def generate_keycodes_for_mask(label, description):
+    def generate_keycodes_for_mask(label, description, requires_feature=None):
         keycodes = []
         for layer in range(layers):
             lbl = "{}({})".format(label, layer)
-            keycodes.append(Keycode(lbl, lbl, description))
+            keycodes.append(Keycode(lbl, lbl, description, requires_feature=requires_feature))
         return keycodes
 
     KEYCODES_LAYERS.clear()
+    KEYCODES_LAYERS.append(Keycode("QK_LAYER_LOCK", "Layer\nLock",
+            "Locks the current layer", alias=["QK_LLCK"], requires_feature="layer_lock"))
 
     if layers >= 4:
         KEYCODES_LAYERS.append(Keycode("FN_MO13", "Fn1\n(Fn3)"))
@@ -864,6 +875,10 @@ def recreate_keyboard_keycodes(keyboard):
     KEYCODES_LAYERS.extend(
         generate_keycodes_for_mask("DF",
                                    "Set the base (default) layer"))
+    KEYCODES_LAYERS.extend(
+        generate_keycodes_for_mask("PDF",
+                                   "Persistently set the base (default) layer",
+                                   requires_feature="persistent_default_layer"))
     KEYCODES_LAYERS.extend(
         generate_keycodes_for_mask("TG",
                                    "Toggle layer on or off"))
@@ -903,6 +918,9 @@ def recreate_keyboard_keycodes(keyboard):
     create_midi_keycodes(keyboard.midi)
 
     recreate_keycodes()
+
+    # Keep only keycodes where .requires_feature is supported by the keyboard.
+    KEYCODES[:] = list(filter(lambda kc: kc.is_supported_by(keyboard), KEYCODES))
 
 
 recreate_keycodes()

--- a/src/main/python/keycodes/keycodes_v5.py
+++ b/src/main/python/keycodes/keycodes_v5.py
@@ -577,9 +577,9 @@ class keycodes_v5:
         "RM_SPDD": 0x999c,
         "QK_REBOOT": 0x999d,
 
-        "QK_PERSISTENT_DEF_LAYER": 0,
-        "QK_CAPS_WORD_TOGGLE": 0,
-        "QK_LAYER_LOCK": 0,
+        "QK_CAPS_WORD_TOGGLE": 0x999e,
+        "QK_LAYER_LOCK": 0x999f,
+        "QK_PERSISTENT_DEF_LAYER": 0x99a0,  # Reserve 0x99a0 - 0x99bf.
     }
 
     masked = set()

--- a/src/main/python/keycodes/keycodes_v5.py
+++ b/src/main/python/keycodes/keycodes_v5.py
@@ -576,6 +576,10 @@ class keycodes_v5:
         "RM_SPDU": 0x999b,
         "RM_SPDD": 0x999c,
         "QK_REBOOT": 0x999d,
+
+        "QK_PERSISTENT_DEF_LAYER": 0,
+        "QK_CAPS_WORD_TOGGLE": 0,
+        "QK_LAYER_LOCK": 0,
     }
 
     masked = set()

--- a/src/main/python/keycodes/keycodes_v5.py
+++ b/src/main/python/keycodes/keycodes_v5.py
@@ -596,6 +596,7 @@ for x in range(32):
     keycodes_v5.kc["TT({})".format(x)] = keycodes_v5.kc["QK_LAYER_TAP_TOGGLE"] | x
     keycodes_v5.kc["OSL({})".format(x)] = keycodes_v5.kc["QK_ONE_SHOT_LAYER"] | x
     keycodes_v5.kc["TO({})".format(x)] = keycodes_v5.kc["QK_TO"] | (1 << 4) | x
+    keycodes_v5.kc["PDF({})".format(x)] = keycodes_v5.kc["QK_PERSISTENT_DEF_LAYER"] + x
 
 for x in range(16):
     keycodes_v5.kc["LT{}(kc)".format(x)] = keycodes_v5.kc["QK_LAYER_TAP"] | (((x) & 0xF) << 8)

--- a/src/main/python/keycodes/keycodes_v6.py
+++ b/src/main/python/keycodes/keycodes_v6.py
@@ -14,6 +14,7 @@ class keycodes_v6:
         "QK_TO": 0x5200,
         "QK_MOMENTARY": 0x5220,
         "QK_DEF_LAYER": 0x5240,
+        "QK_PERSISTENT_DEF_LAYER": 0x52E0,
         "QK_TOGGLE_LAYER": 0x5260,
         "QK_ONE_SHOT_LAYER": 0x5280,
         "QK_ONE_SHOT_MOD": 0x52A0,
@@ -553,8 +554,12 @@ class keycodes_v6:
         "QK_REBOOT": 0x7C01,
         "QK_CLEAR_EEPROM": 0x7C03,
 
+        "QK_CAPS_WORD_TOGGLE": 0x7C73,
+
         "FN_MO13": 0x7C77,
         "FN_MO23": 0x7C78,
+
+        "QK_LAYER_LOCK": 0x7C7B,
 
         "QK_KB": 0x7E00,
 
@@ -590,6 +595,7 @@ for x in range(32):
     keycodes_v6.kc["TT({})".format(x)] = keycodes_v6.kc["QK_LAYER_TAP_TOGGLE"] + x
     keycodes_v6.kc["OSL({})".format(x)] = keycodes_v6.kc["QK_ONE_SHOT_LAYER"] + x
     keycodes_v6.kc["TO({})".format(x)] = keycodes_v6.kc["QK_TO"] + x
+    keycodes_v6.kc["PDF({})".format(x)] = keycodes_v6.kc["QK_PERSISTENT_DEF_LAYER"] + x
 
 for x in range(16):
     keycodes_v6.kc["LT{}(kc)".format(x)] = keycodes_v6.kc["QK_LAYER_TAP"] | (((x) & 0xF) << 8)

--- a/src/main/python/protocol/constants.py
+++ b/src/main/python/protocol/constants.py
@@ -63,5 +63,3 @@ VIAL_PROTOCOL_QMK_SETTINGS = 4
 # When did we get support for 2-byte macros
 VIAL_PROTOCOL_EXT_MACROS = 5
 VIAL_PROTOCOL_KEY_OVERRIDE = 5
-# When did we indicate optionally-supported features.
-VIAL_PROTOCOL_OPTIONAL_FEATURES = 6

--- a/src/main/python/protocol/constants.py
+++ b/src/main/python/protocol/constants.py
@@ -63,3 +63,5 @@ VIAL_PROTOCOL_QMK_SETTINGS = 4
 # When did we get support for 2-byte macros
 VIAL_PROTOCOL_EXT_MACROS = 5
 VIAL_PROTOCOL_KEY_OVERRIDE = 5
+# When did we indicate optionally-supported features.
+VIAL_PROTOCOL_OPTIONAL_FEATURES = 6

--- a/src/main/python/protocol/dummy_keyboard.py
+++ b/src/main/python/protocol/dummy_keyboard.py
@@ -3,6 +3,10 @@ from protocol.keyboard_comm import Keyboard
 
 class DummyKeyboard(Keyboard):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.supported_features = set()
+
     def reload_layers(self):
         self.layers = 4
 

--- a/src/main/python/protocol/dynamic.py
+++ b/src/main/python/protocol/dynamic.py
@@ -3,12 +3,14 @@ import struct
 
 from protocol.base_protocol import BaseProtocol
 from protocol.constants import CMD_VIA_VIAL_PREFIX, CMD_VIAL_DYNAMIC_ENTRY_OP, DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES, \
-    VIAL_PROTOCOL_DYNAMIC
+    VIAL_PROTOCOL_DYNAMIC, VIAL_PROTOCOL_OPTIONAL_FEATURES
 
 
 class ProtocolDynamic(BaseProtocol):
 
     def reload_dynamic(self):
+        self.supported_features = set()
+
         if self.vial_protocol < VIAL_PROTOCOL_DYNAMIC:
             self.tap_dance_count = 0
             self.tap_dance_entries = []
@@ -22,3 +24,17 @@ class ProtocolDynamic(BaseProtocol):
         self.tap_dance_count = data[0]
         self.combo_count = data[1]
         self.key_override_count = data[2]
+
+        if self.vial_protocol >= VIAL_PROTOCOL_OPTIONAL_FEATURES:
+          # Bits of data[-1] indicate optionally supported features.
+          for bit_index, feature in [
+              (0, "caps_word"),
+              (1, "layer_lock"),
+              # Add more feature bits as needed...
+          ]:
+            if data[-1] & (1 << bit_index):
+              self.supported_features.add(feature)
+
+          # Persistent Default Layers isn't present in older QMK builds, but is
+          # unconditionally enabled in recent QMK builds.
+          self.supported_features.add("persistent_default_layer")

--- a/src/main/python/protocol/dynamic.py
+++ b/src/main/python/protocol/dynamic.py
@@ -3,7 +3,7 @@ import struct
 
 from protocol.base_protocol import BaseProtocol
 from protocol.constants import CMD_VIA_VIAL_PREFIX, CMD_VIAL_DYNAMIC_ENTRY_OP, DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES, \
-    VIAL_PROTOCOL_DYNAMIC, VIAL_PROTOCOL_OPTIONAL_FEATURES
+    VIAL_PROTOCOL_DYNAMIC, VIAL_PROTOCOL_KEY_OVERRIDE
 
 
 class ProtocolDynamic(BaseProtocol):
@@ -25,16 +25,16 @@ class ProtocolDynamic(BaseProtocol):
         self.combo_count = data[1]
         self.key_override_count = data[2]
 
-        if self.vial_protocol >= VIAL_PROTOCOL_OPTIONAL_FEATURES:
-          # Bits of data[-1] indicate optionally supported features.
-          for bit_index, feature in [
-              (0, "caps_word"),
-              (1, "layer_lock"),
-              # Add more feature bits as needed...
-          ]:
-            if data[-1] & (1 << bit_index):
-              self.supported_features.add(feature)
+        # Bits of data[-1] indicate optionally supported features.
+        for bit_index, feature in [
+            (0, "caps_word"),
+            (1, "layer_lock"),
+            # Add more feature bits as needed...
+        ]:
+          if data[-1] & (1 << bit_index):
+            self.supported_features.add(feature)
 
+        if self.vial_protocol >= VIAL_PROTOCOL_KEY_OVERRIDE:
           # Persistent Default Layers isn't present in older QMK builds, but is
           # unconditionally enabled in recent QMK builds.
           self.supported_features.add("persistent_default_layer")

--- a/src/main/python/tabbed_keycodes.py
+++ b/src/main/python/tabbed_keycodes.py
@@ -52,7 +52,7 @@ class AlternativeDisplay(QWidget):
         self.buttons = []
 
         for keycode in self.keycodes:
-            if not keycode_filter(keycode.qmk_id):
+            if keycode.hidden or not keycode_filter(keycode.qmk_id):
                 continue
             btn = SquareButton()
             btn.setRelSize(KEYCODE_BTN_RATIO)

--- a/src/main/python/test/test_gui.py
+++ b/src/main/python/test/test_gui.py
@@ -88,7 +88,12 @@ class VirtualKeyboard:
 
     def vial_cmd_dynamic(self, msg):
         if msg[2] == DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES:
-            return struct.pack("BBB", len(self.tap_dance), len(self.combos), self.key_override_entries)
+            response = struct.pack("BBB", len(self.tap_dance), len(self.combos), self.key_override_entries)
+            # Zero pad to 31 bytes.
+            response += (31 - len(response)) * b'\0'
+            # Set last two bits, indicating Caps Word and Layer Lock.
+            response += (0b00000011).to_bytes(1, "little")
+            return response
         elif msg[2] == DYNAMIC_VIAL_COMBO_GET:
             idx = msg[3]
             assert idx < len(self.combos)
@@ -231,6 +236,8 @@ def test_about_keyboard(qtbot):
          'Tap Dance entries: unsupported - disabled in firmware\n'
          'Combo entries: unsupported - disabled in firmware\n'
          'Key Override entries: unsupported - disabled in firmware\n'
+         'Caps Word: yes\n'
+         'Layer Lock: yes\n'
          '\n'
          'QMK Settings: disabled in firmware\n')
     mw.about_dialog.accept()

--- a/src/main/python/test/test_keycode.py
+++ b/src/main/python/test/test_keycode.py
@@ -13,6 +13,10 @@ class FakeKeyboard:
 
     def __init__(self, protocol):
         self.vial_protocol = protocol
+        if protocol >= 6:
+            self.supported_features = set(["persistent_default_layer", "caps_word", "layer_lock"])
+        else:
+            self.supported_features = set()
 
 
 class TestKeycode(unittest.TestCase):


### PR DESCRIPTION
As discussed [in this thread](https://github.com/vial-kb/vial-gui/issues/302), this PR adds GUI changes for QMK's `PDF(layer)` switches, [Caps Word](https://docs.qmk.fm/features/caps_word) and [Layer Lock](https://docs.qmk.fm/features/layer_lock) to vial-gui.

The corresponding Vial firmware change is in https://github.com/vial-kb/vial-qmk/pull/902

Details:

* The last bits of the response to `DYNAMIC_VIAL_GET_NUMBER_OF_ENTRIES` indicate optionally supported features. A `.supported_features` set field in `ProtocolDynamic` remembers which feature bits were set.

* Added a `requires_feature` field to `Keycode` to note when the keycode depends on an optional feature. These keycodes are only shown if the required feature is supported.

* Bumped the Vial protocol version (5 → 6).

Screenshots to showcase the new keycodes:

![vial-layer-keys-gui-screenshot](https://github.com/user-attachments/assets/59e83608-ed3a-44e7-9856-0b2a556200d0)

![vial-quantum-keys-gui-screenshot](https://github.com/user-attachments/assets/7723303c-a553-41fd-9e7d-63b0cd438eb6)

Testing: I tested that this change works as expected on my Moonlander.

