### PR TITLE
set  SUPPORTED_VIA_PROTOCOL to max 11 to make the vial firmware also work with VIA V3 definition.

### DIFF
--- a/src/build/settings/base.json
+++ b/src/build/settings/base.json
@@ -2,5 +2,5 @@
     "app_name": "Vial",
     "author": "xyz",
     "main_module": "src/main/python/main.py",
-    "version": "0.7.4"
+    "version": "0.7.4.1"
 }

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -24,7 +24,7 @@ from protocol.tap_dance import ProtocolTapDance
 from unlocker import Unlocker
 from util import MSG_LEN, hid_send
 
-SUPPORTED_VIA_PROTOCOL = [-1, 9]
+SUPPORTED_VIA_PROTOCOL = [-1, 11]
 SUPPORTED_VIAL_PROTOCOL = [-1, 0, 1, 2, 3, 4, 5, 6]
 
 


### PR DESCRIPTION
When  #define VIA_PROTOCOL_VERSION 0x000B in vial-qmk, the firmware works with VIA by using V3 definition.
However, when vial detects that this value is greater than 9, it will prompt Unsupported protocol version! and cannot be used.
