### PR TITLE
add 11 to SUPPORTED_VIA_PROTOCOL.

### DIFF
--- a/src/build/settings/base.json
+++ b/src/build/settings/base.json
@@ -2,5 +2,5 @@
     "app_name": "Vial",
     "author": "xyz",
     "main_module": "src/main/python/main.py",
-    "version": "0.7.4"
+    "version": "0.7.4.1"
 }

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -24,7 +24,7 @@ from protocol.tap_dance import ProtocolTapDance
 from unlocker import Unlocker
 from util import MSG_LEN, hid_send
 
-SUPPORTED_VIA_PROTOCOL = [-1, 9]
+SUPPORTED_VIA_PROTOCOL = [-1, 11]
 SUPPORTED_VIAL_PROTOCOL = [-1, 0, 1, 2, 3, 4, 5, 6]
 
 

--- a/src/main/python/protocol/keyboard_comm.py
+++ b/src/main/python/protocol/keyboard_comm.py
@@ -24,7 +24,7 @@ from protocol.tap_dance import ProtocolTapDance
 from unlocker import Unlocker
 from util import MSG_LEN, hid_send
 
-SUPPORTED_VIA_PROTOCOL = [-1, 11]
+SUPPORTED_VIA_PROTOCOL = [-1, 9, 11]
 SUPPORTED_VIAL_PROTOCOL = [-1, 0, 1, 2, 3, 4, 5, 6]
 
 


### PR DESCRIPTION
The vial firmware can also be used with https://usevia.app/ in VIAL_PROTOCOL 5.
However, some qmk action codes used by VIAL_PROTOCOL 6 have changed, which results in a mismatch with the default VIA_PROTOCOL 9 key values.
VIA_PROTOCOL 11 also uses the new qmk action code. 

So:
- #define VIA_PROTOCOL_VERSION 0x000B in via.h.
- add SUPPORTED_VIA_PROTOCOL 11 in vial-gui.

Then, we can make the firmware work with both vial-gui and VIA.