### PR TITLE
Fix missing Windows ARP version metadata

### DIFF
--- a/src/build/settings/base.json
+++ b/src/build/settings/base.json
@@ -1,6 +1,6 @@
 {
     "app_name": "Vial",
-    "author": "xyz",
+    "author": "Vial",
     "main_module": "src/main/python/main.py",
     "version": "0.7.5"
 }

--- a/src/installer/windows/Installer.nsi
+++ b/src/installer/windows/Installer.nsi
@@ -72,6 +72,7 @@ Section
   WriteUninstaller "$InstDir\uninstall.exe"
   CreateShortCut "$SMPROGRAMS\${app_name}.lnk" "$InstDir\${app_name}.exe"
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "${app_name}"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "${version}"
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" \
     "$\"$InstDir\uninstall.exe$\" /$MultiUser.InstallMode"
   WriteRegStr SHCTX "${UNINST_KEY}" "QuietUninstallString" \


### PR DESCRIPTION
## Summary
- write `DisplayVersion` into the Windows uninstall registry entry so ARP and winget can detect the installed version
- replace the placeholder Windows publisher metadata from `xyz` to `Vial`

## Why
The current NSIS installer writes `DisplayName`, uninstall commands, and `Publisher`, but not `DisplayVersion`. That leaves the ARP entry without any version metadata, which causes Windows Apps & Features and `winget` to show the installed version as unknown.

## Testing
- not run locally
